### PR TITLE
更新px2rem版本到0.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "px2rem-loader",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "css post loader for px2rem",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Jinjiang/px2rem-loader",
   "dependencies": {
-    "px2rem": "~0.2.2",
+    "px2rem": "~0.4.0",
     "loader-utils": "^0.2.7"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ var loader = require('./lib/px2rem-loader')
 describe('Loader', function () {
 
   it('should transform px value into rem', function () {
-    var output = loader.call({}, 'body {width: 640px}')
+    var output = loader.call({}, 'body {width: 750px}')
     expect(output).is.a('string')
     expect(output).to.equal('body {\n  width: 10rem;\n}')
   })
@@ -13,24 +13,24 @@ describe('Loader', function () {
 describe('Transform Value Comment', function () {
 
   it('should support `no` transform value comment', function () {
-    var output = loader.call({}, 'body {width: 640px; /*no*/}')
+    var output = loader.call({}, 'body {width: 750px; /*no*/}')
     expect(output).is.a('string')
-    expect(output).to.equal('body {\n  width: 640px;\n}')
+    expect(output).to.equal('body {\n  width: 750px;\n}')
   })
 
   it('should support `px` transform value comment', function () {
-    var output = loader.call({}, 'body {width: 640px; /*px*/}')
+    var output = loader.call({}, 'body {width: 750px; /*px*/}')
     expect(output).is.a('string')
-    expect(output).to.equal('\n\n[data-dpr="1"] body {\n  width: 320px;\n}\n\n[data-dpr="2"] body {\n  width: 640px;\n}\n\n[data-dpr="3"] body {\n  width: 960px;\n}')
+    expect(output).to.equal('[data-dpr="1"] body {\n  width: 375px;\n}\n\n[data-dpr="2"] body {\n  width: 750px;\n}\n\n[data-dpr="3"] body {\n  width: 1125px;\n}')
   })
 })
 
 describe('Loader Query', function () {
 
   it('should support `remUnit` query', function () {
-    var output = loader.call({query: '?remUnit=75'}, 'body {width: 640px}')
+    var output = loader.call({query: '?remUnit=64'}, 'body {width: 640px}')
     expect(output).is.a('string')
-    expect(output).to.equal('body {\n  width: 8.533333rem;\n}')
+    expect(output).to.equal('body {\n  width: 10rem;\n}')
   })
 
   it('should support `remUnit` query', function () {
@@ -40,9 +40,9 @@ describe('Loader Query', function () {
   })
 
   it('should support `remPrecision` query', function () {
-    var output = loader.call({query: '?remPrecision=3'}, 'body {width: 999px}')
+    var output = loader.call({query: '?remPrecision=3'}, 'body {width: 1000px}')
     expect(output).is.a('string')
-    expect(output).to.equal('body {\n  width: 15.609rem;\n}')
+    expect(output).to.equal('body {\n  width: 13.333rem;\n}')
   })
 
   it('should support `remUnit` & `remPrecision` query', function () {


### PR DESCRIPTION
主要更新：

* 生成的带 [data-dpr] 规则紧跟原规则，而不是都放在样式表的最后
* 修改默认的remUnit值为75