### PR TITLE
feat:add exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ module.exports = {
         // options here
         options: {
           remUnit: 75,
-          remPrecision: 8
+          remPrecision: 8,
+           exclude:/antd\.css/
         }
       }]
     }]

--- a/lib/px2rem-loader.js
+++ b/lib/px2rem-loader.js
@@ -3,6 +3,9 @@ var Px2rem = require('px2rem')
 
 module.exports = function (source) {
   var options = loaderUtils.getOptions(this)
+  if (options.exclude && options.exclude.test(this.resource)) {
+    return source
+  }
   var px2remIns = new Px2rem(options)
   return px2remIns.generateRem(source)
 }


### PR DESCRIPTION
**第三方框架样式问题** 
如果第三方组件已经是为移动端做了适配,px2rem又转成了rem就导致其样式变的很小
添加**exclude**参数 排除组件库样式文件转换